### PR TITLE
Add DiscoveryInfo to task

### DIFF
--- a/memsql_framework/scheduler/scheduler.py
+++ b/memsql_framework/scheduler/scheduler.py
@@ -81,7 +81,7 @@ class MemSQLScheduler(Scheduler):
             ddd_resources.scalar.value = disk
         return task
 
-    def make_agent_task(self, offer, cpu, mem, disk, host_ip, agent_host, agent_port, memsql_port, demo_port, memsql_role, cluster_name, install_demo, agent_version, primary_host=None, primary_memsql_port=None):
+    def make_agent_task(self, offer, cpu, mem, disk, host_ip, agent_host, agent_port, memsql_port, demo_port, memsql_role, cluster_name, display_name, install_demo, agent_version, primary_host=None, primary_memsql_port=None):
         agent_task = self.make_task(offer, cpu, mem, disk)
         agent_task.name = "agent task %s" % agent_task.task_id.value
         agent_task.command.value = "/sbin/my_init"

--- a/memsql_framework/scheduler/scheduler.py
+++ b/memsql_framework/scheduler/scheduler.py
@@ -89,6 +89,11 @@ class MemSQLScheduler(Scheduler):
         agent_task.container.docker.image = "memsql/mesos-executor:latest"
         agent_task.container.docker.force_pull_image = True
 
+        if memsql_role = const.MemSQLRole.MASTER:
+            agent_task.discovery               = mesos_pb2.DiscoveryInfo()
+            agent_task.discovery.visibility    = mesos_pb2.DiscoveryInfo.Visibility.EXTERNAL
+            agent_task.discovery.name          = agent_host
+
         port_resource = agent_task.resources.add()
         port_resource.name = "ports"
         port_resource.role = MEMSQL_SCHEDULER_ROLE


### PR DESCRIPTION
Can someone take a look at how this should be done?
We'd like to be able to set a DNS record in mesos for the memsql master.
Ideally, it should also include the cluster name in the DNS, which would need to be exposed as a label in DiscoveryInfo perhaps?
Currently, there will be an issue if the framework starts more than one cluster.